### PR TITLE
Fix version compatibility issue between browserify and grunt-browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
-    "browserify": "~2.33.1",
-    "grunt-browserify": "~1.2.8",
+    "browserify": "2.x.x",
+    "grunt-browserify": "1.2.x",
     "karma-script-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
     "karma-firefox-launcher": "~0.1.0",


### PR DESCRIPTION
Thix PR fix a compatibility  issue between grunt-browserify and browserify

grunt-browserify wants browserify@>=2.35 < 3.0.0

```
npm install

npm ERR! peerinvalid The package browserify does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-browserify@1.2.11 wants browserify@>=2.35 < 3.0.0
```
